### PR TITLE
fix: update references from run_all.py to run.py

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
           REDIS_HOST: localhost
           REDIS_PORT: 6379
         run: |
-          python benchmarks/run_all.py --iterations 5 --concurrency 10
+          python benchmarks/run.py --iterations 5 --concurrency 10
 
   build:
     name: Build and Push Docker Image

--- a/benchmarks/Dockerfile
+++ b/benchmarks/Dockerfile
@@ -14,4 +14,4 @@ ENV API_BASE_URL=http://api:8000
 ENV PYTHONUNBUFFERED=1
 
 # Default command (can be overridden)
-CMD ["python", "run_all.py"] 
+CMD ["python", "run.py"] 


### PR DESCRIPTION
This pull request includes changes to streamline the benchmarking process by updating the script filenames used in the workflow and Dockerfile.

Updates to benchmarking scripts:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L72-R72): Changed the script executed in the benchmarking step from `run_all.py` to `run.py` to align with the updated script structure.
* [`benchmarks/Dockerfile`](diffhunk://#diff-e18f205f6de4cca0a1ec574dbe029bf1a139f6b67af80a37f02bd696f417c70cL17-R17): Updated the default command to use `run.py` instead of `run_all.py` to match the new script naming convention.